### PR TITLE
fix: Fix type errors when verbatimModuleSyntax is enabled

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,4 @@
-import { AstroIntegration } from "astro";
+import type { AstroIntegration } from "astro";
 import fs from "fs/promises";
 
 const PKG_NAME = "astro-preload";


### PR DESCRIPTION
Using a type-only import