### PR TITLE
fix(readme): Change npm install command to npx, while replacing install with add

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Can be useful in combination with tools like [astro-compress](https://github.com
 
 ## Install
 ```bash
-npm run astro install astro-preload
+npx astro add astro-preload
 # or
 yarn astro add astro-preload
 ```


### PR DESCRIPTION
This is just a very minor change to the README. The current file tells you to run `npm run astro install astro-preload`. This seems to be wrong, as shown below:
![image](https://github.com/LyonSyonII/astro-preload/assets/27686785/57f44f19-8d30-44bd-99fd-34f445e9ba55)

I have replaced the command with `npx astro add  astro-preload`:

 
![image](https://github.com/LyonSyonII/astro-preload/assets/27686785/c11960f2-cf07-4bc8-a444-ac98ed263611)
